### PR TITLE
Update alias and simplify paper gradle-kts markdown

### DIFF
--- a/files/minecraft/paper-gradle-kts/build.gradle.kts
+++ b/files/minecraft/paper-gradle-kts/build.gradle.kts
@@ -1,0 +1,57 @@
+plugins {
+    java
+    id("net.minecrell.plugin-yml.bukkit") version "0.6.0"
+    // Falls du Abhängigkeiten in deinem Plugin benötigst, welche nicht von Paper oder anderen Plugins bereitgestellt werden.
+    // id("com.github.johnrengelman.shadow") version "8.1.1"
+}
+
+group = "com.example"
+version = "1.0.0"
+
+repositories {
+    mavenCentral()
+    maven("https://repo.papermc.io/repository/maven-public/")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+    withSourcesJar()
+    withJavadocJar()
+}
+
+dependencies {
+    compileOnly("io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT")
+}
+
+tasks {
+    compileJava {
+        options.encoding = "UTF-8"
+    }
+
+    compileTestJava {
+        options.encoding = "UTF-8"
+    }
+
+    javadoc {
+        options.encoding = "UTF-8"
+    }
+
+    // Falls du shadow benutzt
+    //build {
+    //    dependsOn(shadowJar)
+    //}
+    //shadowJar {
+    //    val mapping = mapOf("com.example.mylib" to "mylib")
+    //    val base = "com.example.myplugin.libs."
+    //    for ((pattern, name) in mapping) relocate(pattern, "${base}${name}")
+    //}
+
+}
+
+bukkit {
+    // Dokumentation für Befehle etc gibts hier https://github.com/Minecrell/plugin-yml#bukkit
+    name = "MyPlugin"
+    main = "com.example.myplugin.MyPlugin"
+}

--- a/minecraft/paper-gradle-kts.md
+++ b/minecraft/paper-gradle-kts.md
@@ -9,5 +9,5 @@ Wir beginnen mit dem grundlegenden Gradle-Layout, legen Repositories und Abhäng
 
 [Hier gehts zum Blog Post](<https://chojo.dev/blog/de/gradle_minecraft_basic_and_advanced/>)
 
-Wenn du einfach nur auf der suche nach einer schnellen Referenz bist, schau [hier](<https://haste.devcord.club/orizodomar.java>)
+Wenn du einfach nur auf der Suche nach einer schnellen Referenz bist, schau [hier](<https://haste.devcord.club/orizodomar.java>)
 

--- a/minecraft/paper-gradle-kts.md
+++ b/minecraft/paper-gradle-kts.md
@@ -8,3 +8,6 @@ Anstatt dich mit einer Beispiel-Gradle-Datei zu überschütten, werden wir Schri
 Wir beginnen mit dem grundlegenden Gradle-Layout, legen Repositories und Abhängigkeiten fest und fahren mit Plugins fort.
 
 [Hier gehts zum Blog Post](<https://chojo.dev/blog/de/gradle_minecraft_basic_and_advanced/>)
+
+Wenn du einfach nur auf der suche nach einer schnellen Referenz bist, schau [hier](<https://haste.devcord.club/orizodomar.java>)
+

--- a/minecraft/paper-gradle-kts.md
+++ b/minecraft/paper-gradle-kts.md
@@ -1,50 +1,10 @@
 ---
 tag: paper-gradle-kts
-alias: ["paper-build-kts"]
+alias: ["paper-build-kts", "paper-gradle", "minecraft-gradle"]
 ---
 
-```gradle
-plugins {
-    java
+Die Minecraft-Community hat rund um das Build-Tool Gradle ein riesiges Ökosystem für Minecraft aufgebaut.
+Anstatt dich mit einer Beispiel-Gradle-Datei zu überschütten, werden wir Schritt für Schritt vorgehen.
+Wir beginnen mit dem grundlegenden Gradle-Layout, legen Repositories und Abhängigkeiten fest und fahren mit Plugins fort.
 
-    // falls du weitere Abhängigkeiten in deinem Plugin benötigst, welche nicht von Paper bereitgestellt werden:
-    // id("com.github.johnrengelman.shadow") version "8.1.1"
-}
-
-group = "org.wlosp"
-version = "1.0-SNAPSHOT"
-
-repositories {
-    mavenCentral()
-    maven("https://papermc.io/repo/repository/maven-public/")
-}
-
-dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT")
-}
-
-java.toolchain {
-    languageVersion.set(JavaLanguageVersion.of(17))
-}
-
-tasks {
-    // statt den richtigen Namen und die Version in die plugin.yml zu schreiben
-    // kannst du ${name} und ${version} hineinschreiben und es wird automatisch
-    // mit dem Namen und der Version deines Gradle-Projektes ersetzt
-    processResources {
-        from(sourceSets.main.get().resources.srcDirs) {
-            filesMatching("plugin.yml") {
-                expand(
-                        "version" to project.version,
-                        "name" to project.name
-                )
-            }
-            duplicatesStrategy = DuplicatesStrategy.INCLUDE
-        }
-    }
-}
-```
-
-Falls du die NMS Klassen benötigst, empfiehlt sich das Paperweight-Plugin:
-https://raw.githubusercontent.com/PaperMC/paperweight-test-plugin/master/build.gradle.kts
-https://raw.githubusercontent.com/PaperMC/paperweight-test-plugin/master/settings.gradle.kts
+[Hier gehts zum Blog Post](https://chojo.dev/blog/de/gradle_minecraft_basic_and_advanced/)

--- a/minecraft/paper-gradle-kts.md
+++ b/minecraft/paper-gradle-kts.md
@@ -7,4 +7,4 @@ Die Minecraft-Community hat rund um das Build-Tool Gradle ein riesiges Ökosyste
 Anstatt dich mit einer Beispiel-Gradle-Datei zu überschütten, werden wir Schritt für Schritt vorgehen.
 Wir beginnen mit dem grundlegenden Gradle-Layout, legen Repositories und Abhängigkeiten fest und fahren mit Plugins fort.
 
-[Hier gehts zum Blog Post](https://chojo.dev/blog/de/gradle_minecraft_basic_and_advanced/)
+[Hier gehts zum Blog Post](<https://chojo.dev/blog/de/gradle_minecraft_basic_and_advanced/>)

--- a/minecraft/paper-gradle-kts.md
+++ b/minecraft/paper-gradle-kts.md
@@ -9,5 +9,5 @@ Wir beginnen mit dem grundlegenden Gradle-Layout, legen Repositories und Abhäng
 
 [Hier gehts zum Blog Post](<https://chojo.dev/blog/de/gradle_minecraft_basic_and_advanced/>)
 
-Wenn du einfach nur auf der Suche nach einer schnellen Referenz bist, schau [hier](<https://haste.devcord.club/orizodomar.java>)
+Wenn du einfach nur auf der Suche nach einer schnellen Referenz bist, schau [hier](<https://github.com/devcordde/tags/blob/main/files/minecraft/paper-gradle-kts/build.gradle.kts>)
 


### PR DESCRIPTION
The paper-gradle-kts.md file was updated to include two additional aliases: "paper-gradle" and "minecraft-gradle". The Gradle code snippet was also removed and replace with instructional content, directing users to a blog post for a step-by-step guide on using Gradle in Minecraft. The change was made to provide more comprehensive, user-friendly guide to beginners using Gradle.