### PR TITLE
Add 'userdev' plugin guide

### DIFF
--- a/minecraft/paperweight.md
+++ b/minecraft/paperweight.md
@@ -1,0 +1,13 @@
+---
+tag: paperweight
+alias: ["userdev", "paper-nms", "nms"]
+---
+
+Wenn du nms benutzen möchtest, solltest du das `userdev` Plugin von `paperweight` benutzen.
+Damit kannst du in einer Umgebung mit unverschleierten Namen entwickeln.
+Es ist auch die einzige unterstützte Möglichkeit, auf die Interna von `org.bukkit.craftbukkit.v1_XX_RX` zuzugreifen.
+Es stellt auch sicher, dass du beim Upgrade auf eine neue Version keinen Code ändern musst, der das `net.minecraft` Package verwendet.
+Natürlich musst du trotzdem Code ändern, wenn Mojang etwas geändert hat.
+Du musst auch immer noch die Paketnamen ändern, wenn du internen Code aus `org.bukkit.craftbukkit.v1_XX_RX` verwendest.
+
+Wie du das `userdev` Plugin in gradle einrichtest, erfährst du [hier](<https://chojo.dev/blog/de/gradle_minecraft_basic_and_advanced/#nms-und-internals-mit-paperweight-userdev>)


### PR DESCRIPTION
A new document 'paperweight.md' has been created under the minecraft directory. This file provides instructions for using the 'userdev' plugin from 'paperweight' when working with nms in a Minecraft development environment. This change was made to enhance user guidance and ensure support with the use of obscured names, updating to newer versions, and accessing internals of 'org.bukkit.craftbukkit.v1_XX_RX'.