### PR TITLE
Add guide to 'plugin shading' in Minecraft

### DIFF
--- a/minecraft/plugin-shading.md
+++ b/minecraft/plugin-shading.md
@@ -3,7 +3,7 @@ tag: plugin shading
 alias: ["gradle shading", "minecraft shading"]
 ---
 
-Nehmen wir an unsere Library befindet sich nicht im Maven Central und wir können den Library Loader nicht verwenden.
+Nehmen wir an unsere Library befindet sich nicht im Maven Central und/oder wir können den Library Loader nicht verwenden.
 
 In diesem Fall müssen wir ein anderes Plugin namens shadow verwenden um die Library in unser plugin zu shaden.
 Außerdem müssen wir unsere geshadeten dependencies relocaten um Konflikte mit anderen Plugins zu vermeiden.

--- a/minecraft/plugin-shading.md
+++ b/minecraft/plugin-shading.md
@@ -6,5 +6,6 @@ alias: ["gradle shading", "minecraft shading"]
 Nehmen wir an unsere Library befindet sich nicht im Maven Central und wir können den Library Loader nicht verwenden.
 
 In diesem Fall müssen wir ein anderes Plugin namens shadow verwenden um die Library in unser plugin zu shaden.
+Außerdem müssen wir unsere geshadeten dependencies relocaten um Konflikte mit anderen Plugins zu vermeiden.
 
-Erfahre mehr [hier](<https://chojo.dev/blog/de/gradle_minecraft_basic_and_advanced/#abhangigkeiten-in-unser-jar-shaden>)
+Wie das geht erfährst du [hier](<https://chojo.dev/blog/de/gradle_minecraft_basic_and_advanced/#abhangigkeiten-in-unser-jar-shaden>)

--- a/minecraft/plugin-shading.md
+++ b/minecraft/plugin-shading.md
@@ -1,0 +1,10 @@
+---
+tag: plugin shading
+alias: ["gradle shading", "minecraft shading"]
+---
+
+Nehmen wir an unsere Library befindet sich nicht im Maven Central und wir können den Library Loader nicht verwenden.
+
+In diesem Fall müssen wir ein anderes Plugin namens shadow verwenden um die Library in unser plugin zu shaden.
+
+Erfahre mehr [hier](<https://chojo.dev/blog/de/gradle_minecraft_basic_and_advanced/#abhangigkeiten-in-unser-jar-shaden>)


### PR DESCRIPTION
A new file 'plugin-shading.md' has been introduced in the minecraft directory. It gives developers a solution on how to use the shadow plugin to include libraries which are not available on Maven Central when developing for Minecraft. The link for further guidance on shading dependency into a jar file is also attached. This document is added to fill the information gap on how to make a plugin independent from its dependencies when those are not listed on a standard repository.