### PR TITLE
Bump Java version in java-installation

### DIFF
--- a/java/java-installation.md
+++ b/java/java-installation.md
@@ -6,7 +6,7 @@ image: https://github.com/devcordde/tags/assets/46890129/56cfd7a2-dcb0-423f-b151
 
 ## Anleitung für Windows:
 
-- Java **21** (neuste LTS Version) downloaden (schon ausgewählt) [**JDK (JDK = JRE + Tools)**](<https://adoptium.net/temurin/releases/?variant=openjdk18&jvmVariant=hotspot&version=21&os=windows>) 
+- Java **21** (neuste LTS Version) downloaden (schon ausgewählt) [**JDK (JDK = JRE + Tools)**](<https://adoptium.net/temurin/releases/?jvmVariant=hotspot&version=21&os=windows>) 
 - Datei (.msi) starten
 - Wie im Bild, alles auswählen: auf das X klicken - > Installieren, damit es dann wie im Bild unten aussieht
 - Fertig

--- a/java/java-installation.md
+++ b/java/java-installation.md
@@ -6,7 +6,7 @@ image: https://github.com/devcordde/tags/assets/46890129/56cfd7a2-dcb0-423f-b151
 
 ## Anleitung für Windows:
 
-- Java **18** mit Hotspot downloaden (schon ausgewählt) [**JDK (JDK = JRE + Tools)**](<https://adoptium.net/?variant=openjdk18&jvmVariant=hotspot>) 
+- Java **21** (neuste LTS Version) downloaden (schon ausgewählt) [**JDK (JDK = JRE + Tools)**](<https://adoptium.net/temurin/releases/?variant=openjdk18&jvmVariant=hotspot&version=21&os=windows>) 
 - Datei (.msi) starten
 - Wie im Bild, alles auswählen: auf das X klicken - > Installieren, damit es dann wie im Bild unten aussieht
 - Fertig
@@ -15,7 +15,7 @@ image: https://github.com/devcordde/tags/assets/46890129/56cfd7a2-dcb0-423f-b151
 **SDKMAN!** stellt eine kinderleichte Möglichkeit dar, bspw. Java-Versionen auf Unix-Betriebssystemen zu installieren und zu verwalten.
 - **[SDKMAN!](<https://sdkman.io/install>) installieren**
 - **Liste** der verfügbaren Java-Versionen **anzeigen lassen**: `sdk list java`
-- **Java-Version auswählen** und den **Identifier** (letzte Spalte) **kopieren**. Empfohlen wird die neuste Version von Temurin, 18 (Stand 13.04.22).
+- **Java-Version auswählen** und den **Identifier** (letzte Spalte) **kopieren**. Empfohlen wird die neuste LTS Version von Temurin, 21 (Stand 26.03.24).
 - **Java** mit dem Befehl `sdk install java <Identifier>` **installieren**.
 - Warten und anschließend `y` eingeben, um die neue **Installation als Standard** zu **setzen**
 - Fertig


### PR DESCRIPTION
Die Version ist inzwischen sehr outdated. Ich würde vorschlagen, dass wir immer nur die neuste LTS-Version empfehlen, um den Aufwand für diesen Tag ein wenig zu reduzieren und damit wir nicht einfach irgendwelche random Versionen vorzuschlagen, wenn wir ihn mal vergessen